### PR TITLE
fix mocha's "--compiler" option for CoffeeScript 1.7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: node_js
-before_install:
-  - npm install -g coffee-script mocha
 before_script:
-  - coffee -o ./lib -c -b ./src
+  - node_modules/.bin/coffee -o ./lib -c -b ./src
 node_js:
   - "0.11"
   - "0.10"
-  - "0.8"
-  - "0.6"

--- a/Cakefile
+++ b/Cakefile
@@ -1,13 +1,11 @@
-process.env.NODE_PATH = '/usr/local/lib/node_modules'
-
 cp = require 'child_process'
 
 task 'test','run tests', ->
-    cp.spawn "mocha"
-        ,[ "--compilers","coffee:coffee-script","./test/*.coffee","--reporter","spec"]
+    cp.spawn "./node_modules/.bin/mocha"
+        ,[ "--compilers","coffee:coffee-script/register","./test/*.coffee","--reporter","spec"]
             ,{ stdio: 'inherit' }
 
 task 'compile','compile automate', ->
-  cp.spawn "coffee"
+  cp.spawn "./node_modules/.bin/coffee"
     , [ "-o", "./lib", "-cw", "-b", "./src"]
       ,{ stdio: 'inherit' }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "request": "*"
   },
   "devDependencies": {
-    "coffee-script": "*",
+    "coffee-script": "^1.7.1",
     "mocha":"*"
   },
   "keywords": [
@@ -23,7 +23,7 @@
   },
   "main": "./lib/parse-rss.js",
   "scripts": {
-    "test": "./node_modules/.bin/cake test"
+    "test": "cake test"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
- fixed mocha's option. because it was using option for CoffeeScript1.6.x
- use CoffeeScript 1.7.x or later, specify in `package.json`
- use coffee&mocha&cake command in `./node_modules/.bin/` , not use global installed them.
- remove node.js 0.6 and 0.8 from test target at TravisCI, CoffeeScript1.7.x not works with them.
## test with CoffeeScript 1.7.1

![](http://gyazo.com/93c6541fdb2ef99a9b0ff1e1125f6510.png)
